### PR TITLE
Add design time selector

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,6 @@
 name: Deploy info
 
-# When the "deploy" label is on a PR from a fork,
+# If there is a PR from a fork which has been approved to run GitHub Actions,
 # that PR's head is pushed to a branch directly in the repo (not the fork),
 # so it's deployed by Cloudflare Pages as a branch preview.
 
@@ -37,9 +37,8 @@ jobs:
           inputs.simulate_fork_pr ||
           github.event.pull_request.head.repo.full_name != github.repository
         run: |
-          git config --global url."https://user:${{ secrets.GITHUB_TOKEN }}@github".insteadOf https://github
           git fetch origin ${{ github.sha }}
-          git push origin ${{ github.sha }}:refs/heads/deploy/${{ inputs.simulate_fork_pr || github.event.number }}
+          git push "https://user:${{ secrets.PUSH_GITHUB_TOKEN }}@github.com/${{ github.repository }}" ${{ github.sha }}:refs/heads/deploy/${{ inputs.simulate_fork_pr || github.event.number }}
 
       - name: Get deploy URL
         id: get-url

--- a/src/App/Lab/Page.razor
+++ b/src/App/Lab/Page.razor
@@ -149,6 +149,15 @@
                     </button>
                 }
 
+                @* Design time / runtime toggle *@
+                @if (CurrentCompiledFile?.GetOutput(selectedOutputType)?.DesignTimeText is not null)
+                {
+                    <select class="form-select" title="Generation Strategy" @bind="generationStrategy">
+                        <option value="runtime">Runtime</option>
+                        <option value="@designTime">Design</option>
+                    </select>
+                }
+
                 @* Output loading indicator *@
                 @if (outputLoading)
                 {
@@ -222,6 +231,7 @@
     private string? renamingTo;
     private StandaloneCodeEditor inputEditor = null!;
     private string? selectedOutputType;
+    private string? generationStrategy;
     private bool compilationInProgress;
     private bool outputLoading;
     private CompiledAssembly? compiled;
@@ -229,6 +239,7 @@
     private bool wordWrap;
     private bool useVim;
     private Layout layout;
+    private const string designTime = "designTime";
 
     private sealed record Input(string FileName, TextModel Model)
     {
@@ -514,6 +525,11 @@
         if (output is null)
         {
             return "";
+        }
+
+        if (output.DesignTimeText is not null && generationStrategy == designTime)
+        {
+            return output.DesignTimeText;
         }
 
         if (output.TryGetEagerText(out var text))

--- a/src/Compiler/Compiler.cs
+++ b/src/Compiler/Compiler.cs
@@ -77,17 +77,20 @@ public class Compiler : ICompiler
                 elementSelector: (item) =>
                 {
                     RazorCodeDocument codeDocument = projectEngine.Process(item);
+                    RazorCodeDocument designTimeDocument = projectEngine.ProcessDesignTime(item);
 
                     string syntax = codeDocument.GetSyntaxTree().Serialize();
-
                     string ir = codeDocument.GetDocumentIntermediateNode().Serialize();
-
                     string cSharp = codeDocument.GetCSharpDocument().GeneratedCode;
 
+                    string designSyntax = designTimeDocument.GetSyntaxTree().Serialize();
+                    string designIr = designTimeDocument.GetDocumentIntermediateNode().Serialize();
+                    string designCSharp = designTimeDocument.GetCSharpDocument().GeneratedCode;
+
                     return new CompiledFile([
-                        new("Syntax", syntax),
-                        new("IR", ir),
-                        new("C#", cSharp) { Priority = 1 },
+                        new("Syntax", syntax, designSyntax),
+                        new("IR", ir, designIr),
+                        new("C#", cSharp, designCSharp) { Priority = 1 },
                     ]);
                 });
 

--- a/src/Shared/ICompiler.cs
+++ b/src/Shared/ICompiler.cs
@@ -65,10 +65,11 @@ public sealed class CompiledFileOutput
 {
     private object text;
 
-    public CompiledFileOutput(string type, string eagerText)
+    public CompiledFileOutput(string type, string eagerText, string? designTimeText = null)
     {
         Type = type;
         text = eagerText;
+        DesignTimeText = designTimeText;
     }
 
     public CompiledFileOutput(string type, Func<ValueTask<string>> lazyText)
@@ -85,6 +86,8 @@ public sealed class CompiledFileOutput
 
     public string Type { get; }
     public int Priority { get; init; }
+
+    public string? DesignTimeText { get; }
 
     public bool IsLazy => !TryGetEagerText(out _);
 


### PR DESCRIPTION
For razor, produce both runtime and design time outputs. Add a selector to the UI that allows you to toggle between them.