### PR TITLE
Allow configuring parse options

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,7 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <PackageVersion Include="ICSharpCode.Decompiler" Version="8.2.0.7535" />
     <PackageVersion Include="KristofferStrube.Blazor.WebWorkers" Version="0.1.0-alpha.6" />
+    <PackageVersion Include="MetadataReferenceService.BlazorWasm" Version="0.0.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0-rc.2.24474.3" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.0-rc.2.24474.3" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.0-rc.2.24474.3" />

--- a/src/App/Lab/InitialCode.cs
+++ b/src/App/Lab/InitialCode.cs
@@ -60,6 +60,13 @@ internal sealed record InitialCode(string SuggestedFileName, string TextTemplate
 
         """);
 
+    public static readonly InitialCode Configuration = new("Configuration.cs", """
+        Config.CSharpParseOptions(options => options
+            .WithLanguageVersion(LanguageVersion.Preview)
+            .WithFeatures([new("use-roslyn-tokenizer", "true")]));
+
+        """);
+
     public string SuggestedFileNameWithoutExtension => Path.GetFileNameWithoutExtension(SuggestedFileName);
     public string SuggestedFileExtension => Path.GetExtension(SuggestedFileName);
 

--- a/src/App/Lab/Page.razor
+++ b/src/App/Lab/Page.razor
@@ -42,11 +42,11 @@
                 @* Renaming confirmation *@
                 <input type="text" class="form-control" placeholder="@CurrentInput.FileName" title="File name" @bind="renamingTo" />
                 <button type="button" class="btn btn-outline-primary" title="Confirm rename"
-                        @onclick="RenameInputAsync">
+                @onclick="RenameInputAsync">
                     @BootstrapIcons.CheckLg
                 </button>
                 <button type="button" class="btn btn-outline-secondary" title="Cancel rename"
-                        @onclick="() => renamingTo = null">
+                @onclick="() => renamingTo = null">
                     @BootstrapIcons.XLg
                 </button>
             }
@@ -77,24 +77,35 @@
                             Remove other files
                         </option>
                     }
+                    <hr />
+                    <option value="@((int)SpecialInput.Configuration)">
+                        @if (configuration is null)
+                        {
+                            @:Add configuration
+                        }
+                        else
+                        {
+                            @:Configuration
+                        }
+                    </option>
                 </select>
 
+                @* Rename button *@
                 @if (CurrentInput != null)
                 {
-                    @* Rename button *@
                     <button type="button" class="btn btn-outline-secondary" title="Rename current file"
-                            @onclick="() => renamingTo = CurrentInput.FileName">
+                    @onclick="() => renamingTo = CurrentInput.FileName">
                         @BootstrapIcons.InputCursorText
                     </button>
+                }
 
-                    @* Delete button *@
-                    if (inputs.Count > 1)
-                    {
-                        <button type="button" class="btn btn-outline-danger" title="Delete current file"
-                        @onclick="DeleteInputAsync">
-                            @BootstrapIcons.Trash3
-                        </button>
-                    }
+                @* Delete button *@
+                if (inputs.Count > 1 || CurrentSpecialInput != null)
+                {
+                    <button type="button" class="btn btn-outline-danger" title="Delete current file"
+                    @onclick="DeleteInputAsync">
+                        @BootstrapIcons.Trash3
+                    </button>
                 }
             }
         </div>
@@ -220,19 +231,20 @@
         <div id="vim-status" class="vim-status-bar" hidden="@(!useVim)" />
         <div class="flex-grow-1">
             <BlazorMonaco.Editor.StandaloneCodeEditor @ref="inputEditor" Id="input-editor"
-                ConstructionOptions="EditorConstructionOptions" OnDidInit="EditorInitAsync"
-                OnDidChangeModel="LanguageServices.OnDidChangeModel"
-                OnDidChangeModelContent="LanguageServices.OnDidChangeModelContent" />
+            ConstructionOptions="EditorConstructionOptions" OnDidInit="EditorInitAsync"
+            OnDidChangeModel="LanguageServices.OnDidChangeModel"
+            OnDidChangeModelContent="LanguageServices.OnDidChangeModelContent" />
         </div>
     </div>
     <div class="col" style="@outputStyle">
         <BlazorMonaco.Editor.StandaloneCodeEditor @ref="outputEditor" Id="output-editor"
-            ConstructionOptions="OutputConstructionOptions" />
+        ConstructionOptions="OutputConstructionOptions" />
     </div>
 </div>
 
 @code {
     private readonly List<Input> inputs = new();
+    private Input? configuration;
     private int currentInputIndex;
     private string? renamingTo;
     private StandaloneCodeEditor inputEditor = null!;
@@ -241,7 +253,7 @@
     private string? generationStrategy;
     private bool compilationInProgress;
     private bool outputLoading;
-    private (IEnumerable<InputCode> Input, CompiledAssembly Output)? compiled;
+    private (CompilationInput Input, CompiledAssembly Output)? compiled;
     private Settings settings = null!;
     private bool wordWrap;
     private bool useVim;
@@ -268,6 +280,7 @@
         AddCSharp = -2,
         AddCshtml = -3,
         RemoveOtherFiles = -4,
+        Configuration = -5,
     }
 
     private enum Layout
@@ -287,6 +300,15 @@
             }
 
             return inputs[currentInputIndex];
+        }
+    }
+
+    private SpecialInput? CurrentSpecialInput
+    {
+        get
+        {
+            var result = (SpecialInput)currentInputIndex;
+            return result is SpecialInput.Configuration ? result : null;
         }
     }
 
@@ -420,6 +442,15 @@
                 OnWorkspaceChanged();
                 break;
 
+            case (int)SpecialInput.Configuration:
+                currentInputIndex = (int)SpecialInput.Configuration;
+                configuration ??= new(
+                    InitialCode.Configuration.SuggestedFileName,
+                    await CreateModelAsync(InitialCode.Configuration.ToInputCode()));
+                OnWorkspaceChanged();
+                await inputEditor.SetModel(configuration.Model);
+                break;
+
             case var _ when selectedInputIndex >= 0 && selectedInputIndex < inputs.Count:
                 currentInputIndex = selectedInputIndex;
                 await inputEditor.SetModel(inputs[selectedInputIndex].Model);
@@ -456,14 +487,22 @@
 
     private async Task DeleteInputAsync()
     {
-        Debug.Assert(CurrentInput != null && inputs.Count > 1);
-
         await SaveStateToUrlAsync();
 
-        inputs.RemoveAt(currentInputIndex);
+        switch (currentInputIndex)
+        {
+            case (int)SpecialInput.Configuration:
+                configuration = null;
+                break;
+            default:
+                Debug.Assert(CurrentInput != null && inputs.Count > 1);
+                inputs.RemoveAt(currentInputIndex);
+                break;
+        }
+
         currentInputIndex = 0;
         OnWorkspaceChanged();
-        await inputEditor.SetModel(CurrentInput.Model);
+        await inputEditor.SetModel(CurrentInput!.Model);
 
         await SaveStateToUrlAsync();
     }
@@ -507,8 +546,9 @@
         await RefreshAsync();
 
         // Compile.
-        var result = await Worker.CompileAsync(savedState.Inputs);
-        compiled = (savedState.Inputs, result);
+        var input = savedState.ToCompilationInput();
+        var result = await Worker.CompileAsync(input);
+        compiled = (input, result);
 
         await DisplaySquiggles();
 
@@ -588,7 +628,7 @@
 
         return "";
 
-        async Task<string> loadAsync(IEnumerable<InputCode> inputs, string? file, string outputType)
+        async Task<string> loadAsync(CompilationInput input, string? file, string outputType)
         {
             outputLoading = true;
             await RefreshAsync();
@@ -596,7 +636,7 @@
             // The text will be cached and loaded synchronously next.
             var result = await output.GetTextAsync(outputFactory: async () =>
             {
-                return await Worker.GetOutputAsync(inputs, file: file, outputType: outputType);
+                return await Worker.GetOutputAsync(input, file: file, outputType: outputType);
             });
 
             outputLoading = false;

--- a/src/App/Lab/Settings.razor
+++ b/src/App/Lab/Settings.razor
@@ -27,7 +27,7 @@
                     @* Word wrap check box *@
                     <div class="form-check">
                         <input class="form-check-input" type="checkbox" id="wordWrap" @bind="WordWrap"
-                            @bind:after="OnWordWrapChanged" />
+                        @bind:after="OnWordWrapChanged" />
                         <label class="form-check-label" for="wordWrap">
                             Word wrap
                         </label>
@@ -36,7 +36,7 @@
                     @* Use VIM check box *@
                     <div class="form-check">
                         <input class="form-check-input" type="checkbox" id="vim" @bind="UseVim"
-                            @bind:after="OnVimChanged" />
+                        @bind:after="OnVimChanged" />
                         <label class="form-check-label" for="vim">
                             Use VIM
                         </label>
@@ -45,9 +45,9 @@
                     @* Debug logs check box *@
                     <div class="form-check">
                         <input class="form-check-input" type="checkbox" id="debugLogs"
-                            @bind="DebugLogs" @bind:after="OnSetDebugLogsAsync" />
+                        @bind="DebugLogs" @bind:after="OnSetDebugLogsAsync" />
                         <label class="form-check-label" for="debugLogs"
-                               title="Whether to display debug-level logs in the browser development console">
+                        title="Whether to display debug-level logs in the browser development console">
                             Debug logs
                         </label>
                     </div>
@@ -55,9 +55,9 @@
                     @* Use a worker check box *@
                     <div class="form-check">
                         <input class="form-check-input" type="checkbox" id="enableWorker"
-                            @bind="EnableWorker" @bind:after="OnSetEnableWorkerAsync" />
+                        @bind="EnableWorker" @bind:after="OnSetEnableWorkerAsync" />
                         <label class="form-check-label" for="enableWorker"
-                               title="Moves compilation to a separate worker thread">
+                        title="Moves compilation to a separate worker thread">
                             Use a worker (requires restart)
                         </label>
                     </div>
@@ -65,9 +65,9 @@
                     @* Language services check box *@
                     <div class="form-check">
                         <input class="form-check-input" type="checkbox" id="enableLanguageServices"
-                               @bind="EnableLanguageServices" @bind:after="OnSetEnableLanguageServicesAsync" />
+                        @bind="EnableLanguageServices" @bind:after="OnSetEnableLanguageServicesAsync" />
                         <label class="form-check-label" for="enableLanguageServices"
-                               title="Completions, live diagnostics">
+                        title="Completions, live diagnostics">
                             <span class="badge bg-secondary text-capitalize">experimental</span>
                             Language services (requires restart)
                         </label>
@@ -82,8 +82,8 @@
                                 SDK
                             </label>
                             <input type="text" class="form-control" id="sdkVersion"
-                                   @bind="sdkVersion" @bind:after="() => LoadSdkInfoAsync()"
-                                   placeholder="version" />
+                            @bind="sdkVersion" @bind:after="() => LoadSdkInfoAsync()"
+                            placeholder="version" />
                             @if (loadingSdkInfo)
                             {
                                 <span class="input-group-text">
@@ -100,7 +100,7 @@
                             <div class="form-text">
                                 SDK @(sdkInfo.SdkVersion)
                                 (<a href="@sdkInfo.Commit.Url"
-                                    target="_blank">@sdkInfo.Commit.ShortHash</a>)
+                                target="_blank">@sdkInfo.Commit.ShortHash</a>)
                                 has roslyn @(sdkInfo.RoslynVersion)
                                 and razor @(sdkInfo.RazorVersion).
                             </div>
@@ -120,8 +120,8 @@
                                 Roslyn
                             </label>
                             <input type="text" class="form-control" id="roslynVersion"
-                                   @bind="roslynVersion" @bind:after="() => LoadRoslynInfoAsync()"
-                                   placeholder="version" />
+                            @bind="roslynVersion" @bind:after="() => LoadRoslynInfoAsync()"
+                            placeholder="version" />
                             @if (loadingRoslynInfo)
                             {
                                 <span class="input-group-text">
@@ -132,12 +132,12 @@
                         <div class="form-text">
                             See
                             <a href="@NuGetUtil.GetPackageVersionListUrl(CompilerConstants.RoslynPackageId)"
-                               target="_blank">available Roslyn versions</a>.
+                            target="_blank">available Roslyn versions</a>.
                             Use
                             @if (roslynVersion != "latest")
                             {
                                 <a href="javascript:void" @onclick:preventDefault
-                                    @onclick="@(() => UseRoslynVersionAsync("latest"))">latest</a>
+                                @onclick="@(() => UseRoslynVersionAsync("latest"))">latest</a>
                             }
                             @if (!string.IsNullOrWhiteSpace(roslynVersion))
                             {
@@ -146,7 +146,7 @@
                                     @(" or ")
                                 }
                                 <a href="javascript:void" @onclick:preventDefault
-                                    @onclick="@(() => UseRoslynVersionAsync(null))">built-in</a>
+                                @onclick="@(() => UseRoslynVersionAsync(null))">built-in</a>
                             }
                             @(".")
                         </div>
@@ -155,7 +155,7 @@
                             <div class="form-text">
                                 Using @(roslynInfo.Version)
                                 (<a href="@roslynInfo.Commit.Url"
-                                    target="_blank">@roslynInfo.Commit.ShortHash</a>).
+                                target="_blank">@roslynInfo.Commit.ShortHash</a>).
                             </div>
                         }
                         @if (roslynError != null)
@@ -173,8 +173,8 @@
                                 Razor
                             </label>
                             <input type="text" class="form-control" id="razorVersion"
-                                   @bind="razorVersion" @bind:after="() => LoadRazorInfoAsync()"
-                                   placeholder="version" />
+                            @bind="razorVersion" @bind:after="() => LoadRazorInfoAsync()"
+                            placeholder="version" />
                             @if (loadingRazorInfo)
                             {
                                 <span class="input-group-text">
@@ -185,12 +185,12 @@
                         <div class="form-text">
                             See
                             <a href="@NuGetUtil.GetPackageVersionListUrl(CompilerConstants.RazorPackageId)"
-                               target="_blank">available Razor versions</a>.
+                            target="_blank">available Razor versions</a>.
                             Use
                             @if (razorVersion != "latest")
                             {
                                 <a href="javascript:void" @onclick:preventDefault
-                                    @onclick="@(() => UseRazorVersionAsync("latest"))">latest</a>
+                                @onclick="@(() => UseRazorVersionAsync("latest"))">latest</a>
                             }
                             @if (!string.IsNullOrWhiteSpace(razorVersion))
                             {
@@ -199,7 +199,7 @@
                                     @(" or ")
                                 }
                                 <a href="javascript:void" @onclick:preventDefault
-                                    @onclick="@(() => UseRazorVersionAsync(null))">built-in</a>
+                                @onclick="@(() => UseRazorVersionAsync(null))">built-in</a>
                             }
                             @(".")
                         </div>
@@ -208,7 +208,7 @@
                             <div class="form-text">
                                 Using @(razorInfo.Version)
                                 (<a href="@razorInfo.Commit.Url"
-                                    target="_blank">@razorInfo.Commit.ShortHash</a>).
+                                target="_blank">@razorInfo.Commit.ShortHash</a>).
                             </div>
                         }
                         @if (razorError != null)
@@ -318,6 +318,7 @@
             LanguageServices.Disabled = true;
         }
 
+        Worker.DebugLogs = DebugLogs;
         Worker.Disabled = !EnableWorker;
     }
 

--- a/src/Compiler/Api.cs
+++ b/src/Compiler/Api.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.CodeAnalysis.CSharp;
+
+namespace DotNetInternals;
+
+public static class Config
+{
+    internal static CSharpParseOptions CurrentCSharpParseOptions { get; set; } = Microsoft.CodeAnalysis.CSharp.CSharpParseOptions.Default;
+
+    public static void CSharpParseOptions(Func<CSharpParseOptions, CSharpParseOptions> configure)
+    {
+        CurrentCSharpParseOptions = configure(CurrentCSharpParseOptions);
+    }
+}

--- a/src/Compiler/Api.cs
+++ b/src/Compiler/Api.cs
@@ -6,6 +6,11 @@ public static class Config
 {
     internal static CSharpParseOptions CurrentCSharpParseOptions { get; set; } = Microsoft.CodeAnalysis.CSharp.CSharpParseOptions.Default;
 
+    internal static void Reset()
+    {
+        CurrentCSharpParseOptions = Microsoft.CodeAnalysis.CSharp.CSharpParseOptions.Default;
+    }
+
     public static void CSharpParseOptions(Func<CSharpParseOptions, CSharpParseOptions> configure)
     {
         CurrentCSharpParseOptions = configure(CurrentCSharpParseOptions);

--- a/src/Compiler/Compiler.cs
+++ b/src/Compiler/Compiler.cs
@@ -31,7 +31,7 @@ public class Compiler(ILogger<Compiler> logger) : ICompiler
 
     private CompiledAssembly CompileNoCache(CompilationInput compilationInput, ImmutableDictionary<string, ImmutableArray<byte>>? assemblies, AssemblyLoadContext alc)
     {
-        // Keep consistent with `InitialInput.Configuration`.
+        // IMPORTANT: Keep consistent with `InitialInput.Configuration`.
         var parseOptions = new CSharpParseOptions(LanguageVersion.Preview)
             .WithFeatures([new("use-roslyn-tokenizer", "true")]);
 
@@ -273,8 +273,6 @@ public class Compiler(ILogger<Compiler> logger) : ICompiler
                     References = references,
                 });
 
-                var useRoslynTokenizer = parseOptions.Features.TryGetValue("use-roslyn-tokenizer", out var useRoslynTokenizerValue) &&
-                    string.Equals(useRoslynTokenizerValue, bool.TrueString, StringComparison.OrdinalIgnoreCase);
                 b.Features.Add(new ConfigureRazorParserOptions(parseOptions));
 
                 CompilerFeatures.Register(b);

--- a/src/Compiler/Compiler.csproj
+++ b/src/Compiler/Compiler.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <PackageReference Include="Basic.Reference.Assemblies.AspNet90" />
+    <PackageReference Include="MetadataReferenceService.BlazorWasm" />
     <PackageReference Include="ICSharpCode.Decompiler" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.Net.Compilers.Razor.Toolset" PrivateAssets="all" IncludeAssets="none" GeneratePathProperty="true" />

--- a/src/Shared/Executor.cs
+++ b/src/Shared/Executor.cs
@@ -6,24 +6,53 @@ public static class Executor
 {
     public static string Execute(MemoryStream emitStream)
     {
+        return Execute(emitStream,
+            resultHandler: static (assembly) =>
+            {
+                var entryPoint = assembly.EntryPoint
+                    ?? throw new ArgumentException("No entry point found in the assembly.");
+                int exitCode = 0;
+                Util.CaptureConsoleOutput(
+                    () =>
+                    {
+                        exitCode = InvokeEntryPoint(entryPoint);
+                    },
+                    out string stdout, out string stderr);
+                return $"Exit code: {exitCode}\nStdout:\n{stdout}\nStderr:\n{stderr}";
+            },
+            errorHandler: static (ex) => ex.ToString());
+    }
+
+    public static void Execute(
+        MemoryStream emitStream,
+        Action<Assembly> resultHandler)
+    {
+        Execute<int>(emitStream, assembly =>
+        {
+            resultHandler(assembly);
+            return 0;
+        });
+    }
+
+    public static T Execute<T>(
+        MemoryStream emitStream,
+        Func<Assembly, T> resultHandler,
+        Func<Exception, T>? errorHandler = null)
+    {
         var alc = new AssemblyLoadContext(nameof(Executor));
         try
         {
             var assembly = alc.LoadFromStream(emitStream);
-            var entryPoint = assembly.EntryPoint ??
-                throw new ArgumentException("No entry point found in the assembly.");
-            int exitCode = 0;
-            Util.CaptureConsoleOutput(
-                () =>
-                {
-                    exitCode = InvokeEntryPoint(entryPoint);
-                },
-                out string stdout, out string stderr);
-            return $"Exit code: {exitCode}\nStdout:\n{stdout}\nStderr:\n{stderr}";
+            return resultHandler(assembly);
         }
         catch (Exception ex)
         {
-            return ex.ToString();
+            if (errorHandler is null)
+            {
+                throw;
+            }
+
+            return errorHandler(ex);
         }
     }
 

--- a/src/Shared/Executor.cs
+++ b/src/Shared/Executor.cs
@@ -6,53 +6,27 @@ public static class Executor
 {
     public static string Execute(MemoryStream emitStream)
     {
-        return Execute(emitStream,
-            resultHandler: static (assembly) =>
-            {
-                var entryPoint = assembly.EntryPoint
-                    ?? throw new ArgumentException("No entry point found in the assembly.");
-                int exitCode = 0;
-                Util.CaptureConsoleOutput(
-                    () =>
-                    {
-                        exitCode = InvokeEntryPoint(entryPoint);
-                    },
-                    out string stdout, out string stderr);
-                return $"Exit code: {exitCode}\nStdout:\n{stdout}\nStderr:\n{stderr}";
-            },
-            errorHandler: static (ex) => ex.ToString());
-    }
-
-    public static void Execute(
-        MemoryStream emitStream,
-        Action<Assembly> resultHandler)
-    {
-        Execute<int>(emitStream, assembly =>
-        {
-            resultHandler(assembly);
-            return 0;
-        });
-    }
-
-    public static T Execute<T>(
-        MemoryStream emitStream,
-        Func<Assembly, T> resultHandler,
-        Func<Exception, T>? errorHandler = null)
-    {
         var alc = new AssemblyLoadContext(nameof(Executor));
         try
         {
             var assembly = alc.LoadFromStream(emitStream);
-            return resultHandler(assembly);
+
+            var entryPoint = assembly.EntryPoint
+                ?? throw new ArgumentException("No entry point found in the assembly.");
+
+            int exitCode = 0;
+            Util.CaptureConsoleOutput(
+                () =>
+                {
+                    exitCode = InvokeEntryPoint(entryPoint);
+                },
+                out string stdout, out string stderr);
+
+            return $"Exit code: {exitCode}\nStdout:\n{stdout}\nStderr:\n{stderr}";
         }
         catch (Exception ex)
         {
-            if (errorHandler is null)
-            {
-                throw;
-            }
-
-            return errorHandler(ex);
+            return ex.ToString();
         }
     }
 

--- a/src/Shared/ICompiler.cs
+++ b/src/Shared/ICompiler.cs
@@ -4,7 +4,18 @@ namespace DotNetInternals;
 
 public interface ICompiler
 {
-    CompiledAssembly Compile(IEnumerable<InputCode> inputs);
+    CompiledAssembly Compile(CompilationInput input, ImmutableDictionary<string, ImmutableArray<byte>>? assemblies);
+}
+
+public sealed record CompilationInput
+{
+    public CompilationInput(Sequence<InputCode> inputs)
+    {
+        Inputs = inputs;
+    }
+
+    public Sequence<InputCode> Inputs { get; }
+    public string? Configuration { get; init; }
 }
 
 [ProtoContract]

--- a/src/Shared/ICompiler.cs
+++ b/src/Shared/ICompiler.cs
@@ -1,10 +1,11 @@
 using ProtoBuf;
+using System.Runtime.Loader;
 
 namespace DotNetInternals;
 
 public interface ICompiler
 {
-    CompiledAssembly Compile(CompilationInput input, ImmutableDictionary<string, ImmutableArray<byte>>? assemblies);
+    CompiledAssembly Compile(CompilationInput input, ImmutableDictionary<string, ImmutableArray<byte>>? assemblies, AssemblyLoadContext alc);
 }
 
 public sealed record CompilationInput

--- a/src/Shared/Sequence.cs
+++ b/src/Shared/Sequence.cs
@@ -1,0 +1,89 @@
+﻿using System.Text.Json.Serialization;
+
+namespace DotNetInternals;
+
+/// <summary>
+/// An equatable <see cref="ImmutableArray{T}"/>.
+/// </summary>
+[method: JsonConstructor]
+public readonly struct Sequence<T>(ImmutableArray<T> value) : IEquatable<Sequence<T>>
+{
+    public ImmutableArray<T> Value { get; } = value;
+
+    public bool Equals(Sequence<T> other)
+    {
+        if (Value.IsDefault)
+        {
+            return other.Value.IsDefault;
+        }
+
+        if (other.Value.IsDefault)
+        {
+            return false;
+        }
+
+        var comparer = EqualityComparer<T>.Default;
+        var enu1 = Value.GetEnumerator();
+        var enu2 = other.Value.GetEnumerator();
+        while (true)
+        {
+            bool has1 = enu1.MoveNext();
+            bool has2 = enu2.MoveNext();
+
+            if (has1 != has2)
+            {
+                return false;
+            }
+
+            if (!has1 && !has2)
+            {
+                return true;
+            }
+
+            if (!comparer.Equals(enu1.Current, enu2.Current))
+            {
+                return false;
+            }
+        }
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is Sequence<T> sequence && Equals(sequence);
+    }
+
+    public static bool operator ==(Sequence<T> left, Sequence<T> right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(Sequence<T> left, Sequence<T> right)
+    {
+        return !(left == right);
+    }
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        foreach (var item in Value)
+        {
+            hash.Add(item);
+        }
+        return hash.ToHashCode();
+    }
+
+    public override string ToString()
+    {
+        return Value.IsDefault ? string.Empty : Value.JoinToString(", ");
+    }
+
+    public static implicit operator ImmutableArray<T>(Sequence<T> sequence)
+    {
+        return sequence.Value;
+    }
+
+    public static implicit operator Sequence<T>(ImmutableArray<T> value)
+    {
+        return new(value);
+    }
+}

--- a/src/Shared/Util.cs
+++ b/src/Shared/Util.cs
@@ -113,6 +113,22 @@ public static class Util
         return builder.ToImmutable();
     }
 
+    public static async Task<ImmutableDictionary<TKey, TValue>> ToImmutableDictionaryAsync<T, TKey, TValue>(
+        this IEnumerable<T> source,
+        Func<T, TKey> keySelector,
+        Func<T, Task<TValue>> valueSelector)
+        where TKey : notnull
+    {
+        var builder = ImmutableDictionary.CreateBuilder<TKey, TValue>();
+
+        foreach (var item in source)
+        {
+            builder.Add(keySelector(item), await valueSelector(item));
+        }
+
+        return builder.ToImmutable();
+    }
+
     public static Task<ImmutableDictionary<TKey, TValue>> ToImmutableDictionaryAsync<T, TKey, TValue>(
         this IAsyncEnumerable<T> source,
         Func<T, TKey> keySelector,

--- a/src/Worker/InputMessage.cs
+++ b/src/Worker/InputMessage.cs
@@ -42,21 +42,21 @@ public abstract record WorkerInputMessage
         }
     }
 
-    public sealed record Compile(IEnumerable<InputCode> Inputs) : WorkerInputMessage<CompiledAssembly>
+    public sealed record Compile(CompilationInput Input) : WorkerInputMessage<CompiledAssembly>
     {
         public override async Task<CompiledAssembly> HandleAsync(IServiceProvider services)
         {
             var compiler = services.GetRequiredService<CompilerProxy>();
-            return await compiler.CompileAsync(Inputs);
+            return await compiler.CompileAsync(Input);
         }
     }
 
-    public sealed record GetOutput(IEnumerable<InputCode> Inputs, string? File, string OutputType) : WorkerInputMessage<string>
+    public sealed record GetOutput(CompilationInput Input, string? File, string OutputType) : WorkerInputMessage<string>
     {
         public override async Task<string> HandleAsync(IServiceProvider services)
         {
             var compiler = services.GetRequiredService<CompilerProxy>();
-            var result = await compiler.CompileAsync(Inputs);
+            var result = await compiler.CompileAsync(Input);
             if (File is null)
             {
                 return await result.GetRequiredGlobalOutput(OutputType).GetTextAsync(outputFactory: null);

--- a/src/Worker/Lab/AssemblyDownloader.cs
+++ b/src/Worker/Lab/AssemblyDownloader.cs
@@ -1,5 +1,6 @@
 using System.Collections.Frozen;
 using System.Net.Http.Json;
+using System.Runtime.InteropServices;
 
 namespace DotNetInternals.Lab;
 
@@ -20,7 +21,7 @@ internal sealed class AssemblyDownloader
         return manifest!.Resources.Assembly.Keys.ToFrozenDictionary(n => manifest.Resources.Fingerprinting[n], n => n);
     }
 
-    public async Task<Stream> DownloadAsync(string assemblyFileNameWithoutExtension)
+    public async Task<ImmutableArray<byte>> DownloadAsync(string assemblyFileNameWithoutExtension)
     {
         var fingerprintedFileNames = await this.fingerprintedFileNames.Value;
 
@@ -30,7 +31,8 @@ internal sealed class AssemblyDownloader
             fileName = fingerprintedFileName;
         }
 
-        return await client.GetStreamAsync($"_framework/{fileName}");
+        var bytes = await client.GetByteArrayAsync($"_framework/{fileName}");
+        return ImmutableCollectionsMarshal.AsImmutableArray(bytes);
     }
 
     private sealed class BlazorBootJson

--- a/src/Worker/Lab/CompilerProxy.cs
+++ b/src/Worker/Lab/CompilerProxy.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using MetadataReferenceService.BlazorWasm;
+using Microsoft.Extensions.Logging;
+using System.Runtime.InteropServices;
 using System.Runtime.Loader;
 
 namespace DotNetInternals.Lab;
@@ -23,10 +25,14 @@ internal sealed class CompilerProxy(
     AssemblyDownloader assemblyDownloader,
     CompilerLoaderServices loaderServices)
 {
+    private static readonly Func<Stream, bool, byte[]> convertFromWebcil = typeof(BlazorWasmMetadataReferenceService).Assembly
+        .GetType("MetadataReferenceService.BlazorWasm.WasmWebcil.WebcilConverterUtil")!
+        .GetMethod("ConvertFromWebcil", BindingFlags.Public | BindingFlags.Static)!
+        .CreateDelegate<Func<Stream, bool, byte[]>>();
     private LoadedCompiler? loaded;
     private int iteration;
 
-    public async Task<CompiledAssembly> CompileAsync(IEnumerable<InputCode> inputs)
+    public async Task<CompiledAssembly> CompileAsync(CompilationInput input)
     {
         try
         {
@@ -46,8 +52,14 @@ internal sealed class CompilerProxy(
                 }
             }
 
+            if (input.Configuration is not null && loaded.DllAssemblies is null)
+            {
+                var assemblies = loaded.Assemblies ?? await LoadAssembliesAsync();
+                loaded.DllAssemblies = assemblies.ToImmutableDictionary(p => p.Key, p => WebcilToDll(p.Value.Data));
+            }
+
             using var _ = loaded.LoadContext.EnterContextualReflection();
-            var result = loaded.Compiler.Compile(inputs);
+            var result = loaded.Compiler.Compile(input, loaded.DllAssemblies);
 
             if (loaded.LoadContext is CompilerLoader { LastFailure: { } failure })
             {
@@ -65,8 +77,51 @@ internal sealed class CompilerProxy(
         }
     }
 
+    private static ImmutableArray<byte> WebcilToDll(ImmutableArray<byte> bytes)
+    {
+        var inputStream = new MemoryStream(ImmutableCollectionsMarshal.AsArray(bytes)!);
+        return ImmutableCollectionsMarshal.AsImmutableArray(convertFromWebcil(inputStream, /* wrappedInWebAssembly */ true));
+    }
+
+    private async Task<ImmutableDictionary<string, LoadedAssembly>> LoadAssembliesAsync()
+    {
+        var assemblies = await dependencyRegistry.GetAssembliesAsync()
+            .ToImmutableDictionaryAsync(a => a.Name, a => a, LoadAssemblyAsync,
+            [
+                // All assemblies depending on Roslyn/Razor need to be reloaded
+                // to avoid type mismatches between assemblies from different contexts.
+                // If they are not loaded from the registry, we will reload the built-in ones.
+                // Preload all built-in ones that our Compiler project depends on here
+                // (we cannot do that inside the AssemblyLoadContext because of async).
+                CompilerConstants.CompilerAssemblyName,
+                    CompilerConstants.RoslynAssemblyName,
+                    CompilerConstants.RazorAssemblyName,
+                    "Basic.Reference.Assemblies.AspNet90",
+                    "Microsoft.CodeAnalysis",
+                    "Microsoft.CodeAnalysis.CSharp.Test.Utilities",
+                    "Microsoft.CodeAnalysis.Razor.Test",
+            ]);
+
+        logger.LogDebug("Available assemblies ({Count}): {Assemblies}",
+            assemblies.Count,
+            assemblies.Keys.JoinToString(", "));
+
+        return assemblies;
+    }
+
+    private async Task<LoadedAssembly> LoadAssemblyAsync(string name)
+    {
+        return new()
+        {
+            Name = name,
+            Data = await assemblyDownloader.DownloadAsync(name),
+        };
+    }
+
     private async Task<LoadedCompiler> LoadCompilerAsync()
     {
+        ImmutableDictionary<string, LoadedAssembly>? assemblies = null;
+
         AssemblyLoadContext alc;
         if (dependencyRegistry.IsEmpty)
         {
@@ -75,27 +130,7 @@ internal sealed class CompilerProxy(
         }
         else
         {
-            var assemblies = await dependencyRegistry.GetAssembliesAsync()
-                .ToImmutableDictionaryAsync(a => a.Name, a => a, loadAssemblyAsync,
-                [
-                    // All assemblies depending on Roslyn/Razor need to be reloaded
-                    // to avoid type mismatches between assemblies from different contexts.
-                    // If they are not loaded from the registry, we will reload the built-in ones.
-                    // Preload all built-in ones that our Compiler project depends on here
-                    // (we cannot do that inside the AssemblyLoadContext because of async).
-                    CompilerConstants.CompilerAssemblyName,
-                    CompilerConstants.RoslynAssemblyName,
-                    CompilerConstants.RazorAssemblyName,
-                    "Basic.Reference.Assemblies.AspNet90",
-                    "Microsoft.CodeAnalysis",
-                    "Microsoft.CodeAnalysis.CSharp.Test.Utilities",
-                    "Microsoft.CodeAnalysis.Razor.Test",
-                ]);
-
-            logger.LogDebug("Available assemblies ({Count}): {Assemblies}",
-                assemblies.Count,
-                assemblies.Keys.JoinToString(", "));
-
+            assemblies ??= await LoadAssembliesAsync();
             alc = new CompilerLoader(loaderServices, assemblies, dependencyRegistry.Iteration);
         }
 
@@ -103,22 +138,15 @@ internal sealed class CompilerProxy(
         Assembly compilerAssembly = alc.LoadFromAssemblyName(new(CompilerConstants.CompilerAssemblyName));
         Type compilerType = compilerAssembly.GetType(CompilerConstants.CompilerAssemblyName)!;
         var compiler = (ICompiler)Activator.CreateInstance(compilerType)!;
-        return new() { LoadContext = alc, Compiler = compiler };
-
-        async Task<LoadedAssembly> loadAssemblyAsync(string name)
-        {
-            return new()
-            {
-                Name = name,
-                Data = await assemblyDownloader.DownloadAsync(name),
-            };
-        }
+        return new() { LoadContext = alc, Compiler = compiler, Assemblies = assemblies };
     }
 
     private sealed class LoadedCompiler
     {
         public required AssemblyLoadContext LoadContext { get; init; }
         public required ICompiler Compiler { get; init; }
+        public ImmutableDictionary<string, LoadedAssembly>? Assemblies { get; init; }
+        public ImmutableDictionary<string, ImmutableArray<byte>>? DllAssemblies { get; set; }
     }
 }
 
@@ -174,7 +202,8 @@ internal sealed class CompilerLoader(
             {
                 services.Logger.LogDebug("▶️ {AssemblyName}", assemblyName);
 
-                loaded = LoadFromStream(loadedAssembly.Data);
+                var bytes = ImmutableCollectionsMarshal.AsArray(loadedAssembly.Data)!;
+                loaded = LoadFromStream(new MemoryStream(bytes));
                 loadedAssemblies.Add(name, loaded);
                 return loaded;
             }

--- a/src/Worker/Lab/DependencyRegistry.cs
+++ b/src/Worker/Lab/DependencyRegistry.cs
@@ -47,5 +47,5 @@ internal sealed class DependencyRegistry
 internal sealed class LoadedAssembly
 {
     public required string Name { get; init; }
-    public required Stream Data { get; init; }
+    public required ImmutableArray<byte> Data { get; init; }
 }

--- a/src/Worker/Lab/DependencyRegistry.cs
+++ b/src/Worker/Lab/DependencyRegistry.cs
@@ -44,8 +44,15 @@ internal sealed class DependencyRegistry
     }
 }
 
+internal enum AssemblyDataFormat
+{
+    Dll,
+    Webcil,
+}
+
 internal sealed class LoadedAssembly
 {
     public required string Name { get; init; }
     public required ImmutableArray<byte> Data { get; init; }
+    public required AssemblyDataFormat Format { get; init; }
 }

--- a/src/Worker/Lab/NuGetDownloader.cs
+++ b/src/Worker/Lab/NuGetDownloader.cs
@@ -4,6 +4,7 @@ using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 using System.IO.Compression;
+using System.Runtime.InteropServices;
 
 namespace DotNetInternals.Lab;
 
@@ -133,13 +134,13 @@ internal sealed class NuGetDownloadablePackage
             {
                 ZipArchiveEntry entry = reader.GetEntry(file);
                 using var entryStream = entry.Open();
-                var memoryStream = new MemoryStream(new byte[entry.Length]);
+                var buffer = new byte[entry.Length];
+                var memoryStream = new MemoryStream(buffer);
                 entryStream.CopyTo(memoryStream);
-                memoryStream.Position = 0;
                 return new LoadedAssembly()
                 {
                     Name = entry.Name[..^extension.Length],
-                    Data = memoryStream,
+                    Data = ImmutableCollectionsMarshal.AsImmutableArray(buffer),
                 };
             })
             .ToImmutableArray();

--- a/src/Worker/Lab/NuGetDownloader.cs
+++ b/src/Worker/Lab/NuGetDownloader.cs
@@ -141,6 +141,7 @@ internal sealed class NuGetDownloadablePackage
                 {
                     Name = entry.Name[..^extension.Length],
                     Data = ImmutableCollectionsMarshal.AsImmutableArray(buffer),
+                    Format = AssemblyDataFormat.Dll,
                 };
             })
             .ToImmutableArray();

--- a/src/Worker/Program.cs
+++ b/src/Worker/Program.cs
@@ -5,7 +5,9 @@ using System.Text.Json;
 
 Console.WriteLine("Worker started.");
 
-var serviceProvider = WorkerServices.Create(baseUrl: args[0]);
+var serviceProvider = WorkerServices.Create(
+    baseUrl: args[0],
+    debugLogs: args[1] == bool.TrueString);
 
 Imports.RegisterOnMessage(async e =>
 {

--- a/src/Worker/Utils/SimpleConsoleLoggerProvider.cs
+++ b/src/Worker/Utils/SimpleConsoleLoggerProvider.cs
@@ -24,7 +24,7 @@ internal sealed class SimpleConsoleLoggerProvider : ILoggerProvider
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
         {
-            Console.WriteLine(formatter(state, exception));
+            Console.WriteLine("Worker: {0}", formatter(state, exception));
         }
     }
 }

--- a/src/Worker/WorkerServices.cs
+++ b/src/Worker/WorkerServices.cs
@@ -6,11 +6,16 @@ namespace DotNetInternals;
 
 public static class WorkerServices
 {
-    public static IServiceProvider Create(string baseUrl)
+    public static IServiceProvider Create(string baseUrl, bool debugLogs)
     {
         var services = new ServiceCollection();
         services.AddLogging(builder =>
         {
+            if (debugLogs)
+            {
+                builder.AddFilter("DotNetInternals.*", LogLevel.Debug);
+            }
+
             builder.AddProvider(new SimpleConsoleLoggerProvider());
         });
         services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(baseUrl) });

--- a/test/UnitTests/CompilerProxyTests.cs
+++ b/test/UnitTests/CompilerProxyTests.cs
@@ -1,4 +1,5 @@
 using DotNetInternals.Lab;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit.Abstractions;
 
@@ -9,6 +10,8 @@ public class CompilerProxyTests(ITestOutputHelper output)
     [Fact]
     public async Task SpecifiedNuGetRoslynVersion()
     {
+        var services = new ServiceCollection().AddLogging().BuildServiceProvider();
+
         var nuget = new NuGetDownloader();
         var version = "4.12.0-2.24409.2";
         var commit = "2158b591";
@@ -23,7 +26,8 @@ public class CompilerProxyTests(ITestOutputHelper output)
             NullLogger<CompilerProxy>.Instance,
             deps,
             assemblyDownloader,
-            new(NullLogger<CompilerLoader>.Instance));
+            new(NullLogger<CompilerLoader>.Instance),
+            services);
         var compiled = await compiler.CompileAsync(new(new([new() { FileName = "Input.cs", Text = "#error version" }])));
 
         var diagnosticsText = compiled.GetGlobalOutput(CompiledAssembly.DiagnosticsOutputType)!.EagerText!;
@@ -34,6 +38,8 @@ public class CompilerProxyTests(ITestOutputHelper output)
     [Fact]
     public async Task SpecifiedNuGetRazorVersion()
     {
+        var services = new ServiceCollection().AddLogging().BuildServiceProvider();
+
         var nuget = new NuGetDownloader();
         var version = "9.0.0-preview.24413.5";
         var package = nuget.GetPackage(CompilerConstants.RazorPackageId, version, CompilerConstants.RazorPackageFolder);
@@ -47,7 +53,8 @@ public class CompilerProxyTests(ITestOutputHelper output)
             NullLogger<CompilerProxy>.Instance,
             deps,
             assemblyDownloader,
-            new(NullLogger<CompilerLoader>.Instance));
+            new(NullLogger<CompilerLoader>.Instance),
+            services);
         var compiled = await compiler.CompileAsync(new(new([new() { FileName = "TestComponent.razor", Text = "test" }])));
 
         var cSharpText = compiled.Files.Single().Value.GetOutput("C#")!.EagerText!;

--- a/test/UnitTests/CompilerProxyTests.cs
+++ b/test/UnitTests/CompilerProxyTests.cs
@@ -24,7 +24,7 @@ public class CompilerProxyTests(ITestOutputHelper output)
             deps,
             assemblyDownloader,
             new(NullLogger<CompilerLoader>.Instance));
-        var compiled = await compiler.CompileAsync([new() { FileName = "Input.cs", Text = "#error version" }]);
+        var compiled = await compiler.CompileAsync(new(new([new() { FileName = "Input.cs", Text = "#error version" }])));
 
         var diagnosticsText = compiled.GetGlobalOutput(CompiledAssembly.DiagnosticsOutputType)!.EagerText!;
         output.WriteLine(diagnosticsText);
@@ -48,7 +48,7 @@ public class CompilerProxyTests(ITestOutputHelper output)
             deps,
             assemblyDownloader,
             new(NullLogger<CompilerLoader>.Instance));
-        var compiled = await compiler.CompileAsync([new() { FileName = "TestComponent.razor", Text = "test" }]);
+        var compiled = await compiler.CompileAsync(new(new([new() { FileName = "TestComponent.razor", Text = "test" }])));
 
         var cSharpText = compiled.Files.Single().Value.GetOutput("C#")!.EagerText!;
         output.WriteLine(cSharpText);


### PR DESCRIPTION
Also enables roslyn tokenizer by default. Resolves https://github.com/jjonescz/DotNetInternals/issues/34.