### PR TITLE
Update output when input is switched

### DIFF
--- a/src/App/Lab/Page.razor
+++ b/src/App/Lab/Page.razor
@@ -472,6 +472,9 @@
     {
         currentInputIndex = index;
         await inputEditor.SetModel(inputs[index].Model);
+
+        // Display output corresponding to the selected input.
+        await UpdateOutputDisplayAsync();
     }
 
     private async Task RenameInputAsync()

--- a/src/App/Lab/Page.razor
+++ b/src/App/Lab/Page.razor
@@ -601,12 +601,7 @@
         await outputEditor.SetModel(await BlazorMonaco.Editor.Global.CreateModel(JSRuntime, value: output, language: selectedOutputType == "C#" ? "csharp" : null));
     }
 
-    private CompiledFileOutput? GetOutput(string type)
-    {
-        return GetOutputWithPath(type)?.Output;
-    }
-
-    private (CompiledFileOutput Output, string? File)? GetOutputWithPath(string type)
+    private (CompiledFileOutput Output, string? File)? GetOutput(string type)
     {
         if (CurrentCompiledFile is { } currentCompiledFile)
         {
@@ -626,7 +621,7 @@
 
     private async Task<string> LoadOutput(string type)
     {
-        if (GetOutputWithPath(type) is not (var output, var file))
+        if (GetOutput(type) is not (var output, var file))
         {
             return "";
         }


### PR DESCRIPTION
Fixes a bug where switching to another input (e.g., from TestComponent.razor to _Imports.razor) did not update the output editor to display the generated output corresponding to the currently selected input.